### PR TITLE
Contributing page links not working

### DIFF
--- a/content/dev/Contributing/_index.md
+++ b/content/dev/Contributing/_index.md
@@ -6,10 +6,3 @@ weight: 100
 layout: docs
 
 ---
-
-   - [Introduction](introduction.md) 
-   - [Coding Standards](coding_standards.md)
-   - [Github Workflow](github_workflow.md)
-   - [Pull Requests](pull_requests.md)
-   - [Issues](issues.md)
-   - [Unit Testing](tests.md) 


### PR DESCRIPTION
Autogeneration (with ordering done via weight) is the way to go here. 