### PR TITLE
Add links to old content

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -4,6 +4,7 @@ linkTitle = "Zendocs"
 +++
 
 {{< blocks/cover title="Zen Cart Docs" image_anchor="top" height="full" color="orange" >}}
+<h2>New Documentation</h2>
 <div class="mx-auto">
     <a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/user" >}}">
         Storeowner Docs <i class="fas fa-arrow-alt-circle-right ml-2"></i>
@@ -12,4 +13,12 @@ linkTitle = "Zendocs"
         Developer Docs <i class="fas fa-arrow-alt-circle-right ml-2 "></i>
     </a>
 </div>
+<br /><br />
+<h2>Legacy Documentation</h2>
+<ul>
+  <li style="list-style-type:none"><a href="https://www.zen-cart.com/wiki/index.php/Main_Page">Wiki</a></li>
+  <li style="list-style-type:none"><a href="https://www.zen-cart.com/content.php/2-FAQs-and-Tutorials">Old FAQ</a></li>
+</ul>
 {{< /blocks/cover >}}
+
+


### PR DESCRIPTION
We can get rid of these when the migration is complete, of course.  

Having these links in a well known location would allow us to remove them from the support site header.