### PR TITLE
Move Cindy's Shipping and OT docs out of V2

### DIFF
--- a/content/dev/Code/Modules/_index.md
+++ b/content/dev/Code/Modules/_index.md
@@ -1,0 +1,8 @@
+---
+title: Modules
+category: Zen Cart 
+description: Modules in the Zen Cart Core
+linkTitle: Modules
+weight: 100
+layout: docs
+---

--- a/content/dev/Code/Modules/order_total_modules.md
+++ b/content/dev/Code/Modules/order_total_modules.md
@@ -1,3 +1,6 @@
+---
+title: Order Total Modules
+---
 # Introduction
 Zen Cart *order-total* modules are used to calculate (and display) sub-totals, taxes, totals and other intermediary values for an order. *Order-total* modules can also calculate discounts or other subtractions from the amount a customer owes for an order. Each module includes, at a minimum, two files:
 

--- a/content/dev/Code/Modules/shipping_modules.md
+++ b/content/dev/Code/Modules/shipping_modules.md
@@ -1,3 +1,6 @@
+---
+title: Shipping Modules
+---
 # Introduction
 A shipping module applies a shipping cost to an order, based on some calculation method.  Each shipping module requires a minimum of two files:
 

--- a/content/dev/Code/_index.md
+++ b/content/dev/Code/_index.md
@@ -1,0 +1,7 @@
+---
+title: Code
+linkTitle: Code
+description: Zen Cart Core Code
+weight: 100 
+layout: docs
+---


### PR DESCRIPTION
These are 1.x related files and should be on the /dev site. 
cc @lat9 