### PR TITLE
Bulleted lists must be preceded by blank line

### DIFF
--- a/content/user/admin/centerboxes.md
+++ b/content/user/admin/centerboxes.md
@@ -10,6 +10,7 @@ There is a "New Products for [insert month]" section on several pages, including
 There are several "sets" of settings for the Centerboxes.
 
 When you go to [Admin->Configuration->Index Listing](/user/admin_pages/configuration/configuration_indexlisting/), you will see options like:
+
 - Show New Products on Main Page
 - Show Featured Products on Main Page
 - Show Special Products on Main Page
@@ -18,11 +19,13 @@ When you go to [Admin->Configuration->Index Listing](/user/admin_pages/configura
     - Turn OFF by setting to 0 all of the ones you do NOT want to see displayed ...
 
 The same is true on other similar configuration menus under Admin->Configuration:
+
 - [New Listing](/user/admin_pages/configuration/configuration_newlisting/)
 - [Featured Listing](/user/admin_pages/configuration/configuration_featuredlisting/)
 - [All Listing](/user/admin_pages/configuration/configuration_alllisting/) 
 
 For setting up the Centerboxes of the Empty Shopping Cart, use the settings on the Admin->Configuration->Stock, you will see the settings for:
+
 - Show New Products on Main Page
 - Show Featured Products on Main Page
 - Show Special Products on Main Page

--- a/content/user/admin_pages/catalog/option_name_manager.md
+++ b/content/user/admin_pages/catalog/option_name_manager.md
@@ -67,7 +67,7 @@ The following settings are for image layout purposes
     *   4 = Element (check box/radio button) Below Image and Option Name
     *   5 = Element (check box/radio button) Above Image and Option Name
 
-Click UPDATE.
+Click *UPDATE*.
 
 You now need to set option values in [Admin - Catalog - Option Value Manager](/user/admin_pages/catalog/option_value_manager/) before adding them to your products as attributes (unless you are only using TEXT and FILE).
 

--- a/content/user/admin_pages/discounts/coupon_restrictions.md
+++ b/content/user/admin_pages/discounts/coupon_restrictions.md
@@ -6,6 +6,7 @@ weight: 11
 ---
 
 Coupons can be restricted in the following ways:
+
 - not applying to specific products
 - only applying to specific products 
 

--- a/content/user/first_steps/hosting.md
+++ b/content/user/first_steps/hosting.md
@@ -127,5 +127,6 @@ SSL Certificates are an add-on to a hosting account, and are not directly tied t
 Certificates cannot be directly transferred to another host due to the public/private key generation systems. This is primarily to protect you against theft of identity or the certificate. To move an existing certificate to another server requires that the Issuer (whoever you bought the certificate from originally) re-issue the certificate tied to the new private/public key of your new hosting server, sometimes for a nominal re-issuance fee. Thus, it's simplest to issue certificates around the same time as switching hosting from one place to another.
 
 For more information on SSL, see these articles: 
+
 * [What is an SSL certificate?](/user/security/ssl_cert)
 * [How do I enable SSL?](/user/installing/enable_ssl)

--- a/content/user/first_steps/secure_access.md
+++ b/content/user/first_steps/secure_access.md
@@ -14,6 +14,7 @@ FIXME need content
 Although this was a common way to do it back in 2003, it is no longer a good practice, since it is not secure. 
 
 Some secure options are:
+
 - FTPS
 - SFTP
 - Require explicit FTP over TLS

--- a/content/user/first_steps/server_requirements.md
+++ b/content/user/first_steps/server_requirements.md
@@ -8,7 +8,7 @@ weight: 10
 
 _(Last updated: Dec 1, 2019)_  
 
-Minimum</u> server requirements:  
+*Minimum* server requirements:  
 
 *   Zen Cart operates on a standard "LAMP" stack: PHP, Apache, MySQL on most operating systems (Linux/macOS/Windows)
 *   See the detailed version-compatibility details in the sections below.
@@ -48,6 +48,7 @@ Zen Cart requires a few PHP modules enabled: cURL, MySQLi and Zlib.
 Optional modules: gd and mb_xxxxx. 
 
 <u>**PHP Memory Recommendations**</u>  
+
 - **memory_limit** suggested: **128M** 
 - **post_max_size** and **upload_max_filesize** should be set to whatever max file size you or your customers may upload. Usually **8M** is sufficient for most sites, but if you're accepting huge uploads, set both to the max size of accepted combined uploads.  
 

--- a/content/user/first_steps/yes_you_need_ssl.md
+++ b/content/user/first_steps/yes_you_need_ssl.md
@@ -46,7 +46,8 @@ Then make sure you can visit your site using your SSL URL without getting server
 
 And then you can tell Zen Cart to use your new SSL URL. See the FAQ below for that part.  
 
-Further Related Reading:  
+### Further Related Reading:  
+
 - [How do I enable SSL?](/user/installing/enable_ssl/)
 
 - [What is an SSL certificate?](/user/security/ssl_cert/) 

--- a/content/user/installing/installing_misc.md
+++ b/content/user/installing/installing_misc.md
@@ -44,6 +44,7 @@ The permissions are set on the host server usually through the user's control pa
 ### Connection to Database failed ... Access denied for user: 'myname@localhost' (Using password: YES)
 
 This suggests you have something wrong with any of:
+
 - username
 - password
 - database name
@@ -53,6 +54,7 @@ This suggests you have something wrong with any of:
 When you created your database, did you grant the user access to the database?
 
 Proper database-configuration includes:
+
 - make a database
 - make a user, with password
 - grant the user permission to use the database

--- a/content/user/installing/move_cart.md
+++ b/content/user/installing/move_cart.md
@@ -16,6 +16,7 @@ What steps do I need to follow to move my site to another folder
 on the same server? 
 
 **Answer:**
+
 - Determine the new foldername where your Zen Cart files will be running from
 - In the case above, move your files from `/shop/` to the root level.  
 If you are moving from `/shop/` to `/store/`, rename the folder. 

--- a/content/user/new_user_topics/no_such_file.md
+++ b/content/user/new_user_topics/no_such_file.md
@@ -58,11 +58,13 @@ you need to copy these files to your server.  Use your
 then to the folder where the file is supposed to exist. 
 
 Example: 
+
 - Your webroot is `/home/johndoe/public_html`
 - Your template is `custom`
 - The file you are changing is `includes/languages/custom/english.php`
 
 Steps: 
+
 - Using FTP, connect to `YOURSITE.com`.  
 - Change directories so you get to the webroot.  
 - Change directories from there so that you get to the folder for the file you are changing.  At this point, you will be in `/home/johndoe/public_html/includes/languages/custom`

--- a/content/user/new_user_topics/overrides.md
+++ b/content/user/new_user_topics/overrides.md
@@ -71,10 +71,12 @@ Suppose you want to add a link to the Information Sidebox.
 - Default File: `includes/modules/sideboxes/information.php`
 
 Here are the steps: 
+
 - Create a new directory `/includes/modules/sideboxes/YOURTEMPLATE/` if it doesn't exist 
 - Copy `includes/modules/sideboxes/information.php` to this new directory  
 - You now have `includes/modules/sideboxes/YOURTEMPLATE/information.php`
 - Open the file in a text editor, and add a line to the information array.  We won't use language constants for clarity: 
+
 ```
 $information[] = '<a href="' . zen_href_link(FILENAME_EZPAGES, "id=27") . '">' . "My New EZ-Page". '</a>';
 ```
@@ -86,6 +88,7 @@ Suppose you want to add a link to the Shopping Cart Page
 - Default File: `includes/templates/template_default/templates/tpl_shopping_cart_default.php` 
 
 Here are the steps: 
+
 - Presumably the directory `/includes/templates/YOURTEMPLATE/templates` exists, but if it doesn't, create it. 
 - Copy `includes/templates/template_default/templates/tpl_shopping_cart_default.php` to this new directory  
 - You now have `includes/templates/YOURTEMPLATE/templates/tpl_shopping_cart_default.php`

--- a/content/user/payment/paypal_misc.md
+++ b/content/user/payment/paypal_misc.md
@@ -102,6 +102,7 @@ You can access your Fraud Management Filters settings by logging in to your PayP
 
 
 Your PayPal Express Checkout and/or Website Payments Pro module settings require 4 components to be set correctly in order to talk to PayPal successfully. If any one of them is incorrect, you'll not be able to authenticate and submit transactions:
+
 - API Username
 - API Password
 - API Signature

--- a/content/user/performance/max_file_upload.md
+++ b/content/user/performance/max_file_upload.md
@@ -10,16 +10,20 @@ The ability to upload files to your Zen Cart site via a browser is affected by s
 ### PHP Limits on your Server
 Your hosting company has configured your server with certain capabilities and limitations. The default configuration for PHP uploads is often set at just 2 MB.  Some hosting companies increase this. Some do not.
 It is controlled by the following settings in `php.ini` (which you may or may not have control over):
+
 - post_max_size
 - max_file_uploads
+
 Both of these need to be bigger than the largest file size you want to upload.
 
 ### PHP Timeout Limit on your Server
 The speed of the internet connection between your (or your customer's) computer and your webserver will affect how long it takes to upload files. 
 So, in addition to the size limits, there's also the time required to actually *do* the upload.
 The following settings control the length of time PHP is allowed to wait for an action to complete, including uploading on a page:
+
 - max_execution_time
 - max_input_time
+
 Both of these need to be long enough (in seconds) for the time required for the slowest likely connection to upload the largest likely filesize.
 
 ### Changing these PHP Settings

--- a/content/user/performance/speed_up_site.md
+++ b/content/user/performance/speed_up_site.md
@@ -20,11 +20,12 @@ Go to [Admin->Tools->Layout Boxes Controller](/user/admin_pages/tools/layout_box
 
 3\. Ensure your images are optimized for your site... specifically, use small images for thumbnails, slightly larger for product pages (`_MED` images), and large detailed images for "click to enlarge" (`_LRG`) images.  
 
-Related FAQ articles:  
+### Related FAQ articles:  
 - [Adding Multiple Images To Products](/user/images/images_multiple/) 
 - [Preparing and Optimizing Images](/user/images/images_howto) 
 
 4\. In [Admin->Configuration->Attribute Settings](/user/admin_pages/configuration/configuration_attributesettings/), there are a few switches which, if turned off, will reduce the number of queries used to calculate and display product information:  
+
 - Enable Downloads -- If you're not doing downloads on your site, turn this off.  
 - Enable Price Factor -- If you're not using price-by-attributes support, turn this off to stop those calculations and the related queries  
 - Enable Qty Price Discount -- If you're not doing quantity discounts, turn this off  

--- a/content/user/plugins/best_plugin.md
+++ b/content/user/plugins/best_plugin.md
@@ -25,9 +25,9 @@ when full admin access was not desired.  This feature was pulled in to
 Zen Cart core in the 1.5.0 release, and it's now under the [Admins menu](/user/admin_pages/admins/). 
 
 Similarly, 
+
 - In Zen Cart 1.5.5, **myDEBUG log backtrace** was migrated from a plugin to a core feature.
 - In Zen Cart 1.5.6, **Sales Reports with Graphs** was migrated from a plugin to a core feature. 
-
 - Zen Cart 1.5.7 is slated to embed a 
 number of popular and powerful plugins from the user community. 
 On the list so far are **Default Attribute**, **Report All Errors**, **Ask a Question**, **Sortable Orders Status**, and **zenNonCAPTCHA**. 

--- a/content/user/products/attributes.md
+++ b/content/user/products/attributes.md
@@ -142,6 +142,7 @@ You can look up a product in a couple ways:
 
 **b) Add the Attribute Option Name+Value Pairs**  
 Once the Product is displayed that you want to add attributes to, go to the Add Attributes box  
+
 - The Product Name should already be selected.  
 
 1\. Now select the Option Name  

--- a/content/user/products/downloadable.md
+++ b/content/user/products/downloadable.md
@@ -19,9 +19,11 @@ So, **FIRST you should familiarize yourself with:** [setting up attributes](/use
 2.  Go to **Option Values Manager** and add what you want to call it ...  
     example: **_Zip File_**  
     If you have multiple choices you could have these as the Option Names you create:  
+
     - MS Word Zip  
-    - Note Pad Zip  
+    - Plain Text Zip  
     - etc.
+
 3.  Go to **Attributes Controller** and find the Product ...  
     Add the Attribute as:
 
@@ -182,19 +184,17 @@ If you are using download-by-redirect, then your "pub" folder needs to be read-w
 ## Important Facts about Download Settings
 
 1.  Downloads are NOT Virtual Products so use:  
-    _Product is Virtual: No, Shipping Address Required  
+    *Product is Virtual: No, Shipping Address Required*
 
-    _
 2.  Downloads are NOT Always Free Shipping so use:  
-    _Always Free Shipping: No, Normal Shipping Rules  
+    *Always Free Shipping: No, Normal Shipping Rules*
 
-    _
-3.  Downloads in an order by itself will never see the checkout_shipping page ... if you do then your Product is setup wrong for Downloads  
+3.  Downloads in an order by itself will never see the checkout_shipping page.  If you do then your Product is not setup correctly for Downloads.
 
 4.  If on Linux/Unix, /pub should be writable (usually 777 or 755 depending on the host server) and Redirect should be ON  
     If you cannot use Redirect ON, ask your hosting site why they cannot follow the symbolic link between the `/download` and `/pub` directories  
 
-5.  If on a Windows server, /pub does NOT need to be writable/777 since you do not use this directory because symlinks typically don't work on Windows servers, and Redirect is OFF since Redirect requires symlink support.  
+5.  If on a Windows server, `/pub` does NOT need to be writable/777 since you do not use this directory because symlinks typically don't work on Windows servers, and Redirect is OFF since Redirect requires symlink support.  
 
 6.  Download filenames should not use special characters, spaces, etc  
 
@@ -202,7 +202,7 @@ If you are using download-by-redirect, then your "pub" folder needs to be read-w
 
 8.  Download files should be loaded to the `/download` directory  
 
-9.  On the Admin->Catalog->Attributes Controller you should see a green dot next to the filename of the Download itself
+9.  On the [Admin->Catalog->Attributes Controller](/user/admin_pages/catalog/attributes_controller/) page, you should see a green dot next to the filename of the Download itself.  Similarly, on [Admin->Catalog->Downloads Manager](/user/admin_pages/catalog/downloads_manager/), you should see a green dot next to the file. 
 
 **ALSO:** 
 - See the related article about [Download Delivery Methods](/user/products/download_delivery_methods). 

--- a/content/user/products/products_misc.md
+++ b/content/user/products/products_misc.md
@@ -135,6 +135,7 @@ CAUTION: You need to be sure to ONLY select "product-music" products.  The menus
 
 9. You will need to set up your product Attributes to actually tie the "real" music clips to your products for "Purchase".
 There are a couple tutorials on this process: 
+
 - [Setting up downloads for products](/user/products/downloadable/)
 - [Adding attributes](/user/products/attributes/)
 

--- a/content/user/template/basic_customizations.md
+++ b/content/user/template/basic_customizations.md
@@ -86,6 +86,7 @@ If you wish to change admin functionality, you will have to edit the core files 
 
 This is handled in many ways. 
 There are administrative "switches" under 
+
 - [Admin-> Configuration-> Layout Settings](/user/admin_pages/configuration/configuration_layoutsettings/) 
 - [Admin-> Configuration-> Product Info](/user/admin_pages/configuration/configuration_productinfo/) 
 - [Admin-> Configuration-> Product Listing](/user/admin_pages/configuration/configuration_productlisting/) 

--- a/content/user/template/template_overrides.md
+++ b/content/user/template/template_overrides.md
@@ -66,6 +66,7 @@ You can also place overrides in these folders:
 There are also other mechanisms to allow you modify the 
 behavior of the system without touching core files.
 These are more advanced topics, intended for developers. 
+
 - [Notifiers/Observers](/dev/code/notifiers/)
 - [Init System](/dev/code/init_system/)
 - [Extra folders](/dev/code/extra_folders/) 

--- a/content/user/troubleshooting/cant_stay_logged_in_admin.md
+++ b/content/user/troubleshooting/cant_stay_logged_in_admin.md
@@ -8,6 +8,7 @@ weight: 10
 Before you begin, be sure you are familiar with the structure and contents of [configure.php files](/user/miscellaneous/configure/). 
 
 **THE FIRST THING TO TRY is this:**  
+
 - Close all your browser windows  
 - Open 1 browser window, and use it to clear your browser cache AND cookies.  
 - If you browser has a Private Browsing mode, make sure you're NOT using "Private Browsing" mode, because that will prevent sessions/cookies from being usable  
@@ -19,6 +20,7 @@ Before you begin, be sure you are familiar with the structure and contents of [c
 - Don't use spaces in your domain names, nor in the foldernames in which you've installed your store. If yours has a space in the path anywhere, you may have troubles. Rename the folder instead.  
 
 **NEXT, try to rule out a bad SSL configuration:**  
+
 - If your version is Zen Cart 1.3.9 or before, edit your `/admin/includes/configure.php` and change `ENABLE_SSL_ADMIN` to 'false'  
 - clear browser cache AND cookies and try again  
 then if it's still not working:  
@@ -26,10 +28,12 @@ then if it's still not working:
 - clear browser cache AND cookies and try again  
 
 **IS IT A DOMAIN NAME PROBLEM?**
+
 - if your site is using just an IP address and not a named domain, then it's possible your sessions/cookies are getting confused.  Edit your 2 `configure.php` files and set your `HTTP_SERVER` to an actual domain name, NOT an IP address.  
 - if you're using a domain name with `www` in it, try removing the `www` from it temporarily, again, in the `HTTP_SERVER` setting.  
 
 **IF IT STILL WON'T WORK, read on:**  
+
 - Admin login sessions (and customer login sessions) are managed via the PHP session-handling functionality.  
 - When you log in, a session is generated, and the session's name is zenAdminId or zenid (for the store).  
 - When a session is started, PHP attempts to set a cookie in your browser. That cookie is intended to store that session ID so that it doesn't need to be shown in the browser all the time (ie: with &zenAdminID=243524524524525 etc) at the end of all your URLs.  
@@ -37,6 +41,7 @@ then if it's still not working:
 - When you log out, or the session ID is lost, the session data is reset and your authentication data is removed, requiring login again.  
 
 **Possible causes of session-mgmt problems include:**  
+
 - cookies are blocked by firewall or by browser configuration  
 - PHP is misconfigured or has certain session settings set to methods incompatible with Zen Cart such as session-auto-start and transitive-sid etc. The installer warns about these if they are a problem.  
 - you have your site configured to store session data in files but your filesystem doesn't have permissions set in such a way as to allow storage of the data  
@@ -45,6 +50,7 @@ then if it's still not working:
 Is your "cache" folder set to read/write (ie: chmod 777 (or some other suitable value if 777 is not permitted by your server's configuration) ?  
 
 **Other possibilities:**  
+
 a) altered files on your server. In that case a proper checkup of all your files is in order: see [Diagnosing obscure issues](/user/troubleshooting/diagnosing_obscure_issues/). 
 
 b) a server configuration change by the hosting company (such as a PHP version change or anything else that might result in changes to the master php.ini configuration for the server or your hosting account)

--- a/content/user/troubleshooting/security_error.md
+++ b/content/user/troubleshooting/security_error.md
@@ -22,6 +22,7 @@ If it is happening *all the time* and not just once in awhile, then it could be 
 
 Other Considerations:
 If you're seeing this problem,  then one of the following may be the root cause:
+
 - old obsolete template files, as explained above
 - your browser is unable to set session cookies, or you're using Private Browsing mode or Incognito mode. 
 - you've set your site up on an IP address instead of a domain name, thus preventing session cookies from being set properly

--- a/content/user/troubleshooting/strict_error_reporting.md
+++ b/content/user/troubleshooting/strict_error_reporting.md
@@ -13,6 +13,7 @@ Caveat: Also, using this option poses a security risk because error messages wil
 
 ### Enabling STRICT_ERROR_REPORTING
 To enable `STRICT_ERROR_REPORTING`, simply use your [FTP tool](/user/first_steps/useful_tools/#ftp-tools) to upload a simple file to your store's site like this:
+
 - For storefront problems, put it at: `/includes/local/configure.php`
 - For admin problems, put it at: `/admin/includes/local/configure.php`
 

--- a/content/user/troubleshooting/troubleshooting_misc.md
+++ b/content/user/troubleshooting/troubleshooting_misc.md
@@ -68,11 +68,13 @@ Your hosting company typically provides this via their control panel.
 - Other hosting systems may have the button elsewhere under admin tools
 - H-Sphere customers may have to enable errorlog support before it's available.
 - Some hosts don't offer it via the control panel; they may offer it via a `/logs` folder instead.  Note that this is not your Zen Cart `/logs` folder - it's a above your webroot at the top of your hosting account folder. 
+
 ---
 ### Error 2006 MySQL server has gone away or 2013 Lost connection to MySQL server during query
 "MySQL server has gone away" means that when you clicked on something to ask Zen Cart to do something, it started processing the request, but when it went to retrieve data from the database, it found that the database connection had disconnected, but not by Zen Cart's request.
 
 Possible causes: 
+
 - slow connection to external systems being accessed to produce part of page contents (e.g.: a USPS shipping quote when USPS servers are running slow)
 - your own webserver is running slow (perhaps due to bogged down processing while the server is handling a bunch of spam email, or if your server is overloaded because your hosting company has too many customers on the one server)
 - your hosting company may have configured the server to expire database connections on a very short time period. Most hosts allow connections to remain open for 30 seconds or more, depending on how they have other systems such as PHP configured.
@@ -122,6 +124,7 @@ We suggest using something at least 8 characters long, and including numbers, an
 This is a generic message which usually indicates your site is having problems accessing data in your MySQL database.
 
 It could be a problem with:
+
 - MySQL not running
 - incorrect DB_xxxxxxx settings in either of your configure.php files
 - syntax error in MySQL statements
@@ -151,6 +154,7 @@ There seems to be a problem connecting to our database. Please give us a few min
 ```
 
 Common causes:
+
 - You've changed your database name or database username on your webserver
 - You've deleted the tables from the database on your server
 - You've changed the `DB_PREFIX` setting in your [configure.php files](/user/miscellaneous/configure) to a value that doesn't match the tables in your database
@@ -172,6 +176,7 @@ To remedy this situation, go to [Admin -> Configuration -> Images](/user/admin_p
 On this page is a list of the various image sizes, choose the image size you wish to edit and set one of the dimensions to 0.
 
 Make sure you also set the following two options:
+
 - *Calculate Image Size* = true
 - *Use Proportional Images on Products and Categories* =1.
 

--- a/content/user/troubleshooting/warning_headers_already_sent.md
+++ b/content/user/troubleshooting/warning_headers_already_sent.md
@@ -31,6 +31,7 @@ includes/something_else.php on line 67
 If the "headers already sent" error appears AFTER any other error, then you need to fix that other error FIRST. (The error message itself is what caused headers to be sent, so fixing that error will cause the second error to go away too.)  
 
 If the "started at" refers to line 1, then the root cause is one of two things: 
+
 - a space (possibly a blank line) before the opening **&lt;?php** tag or 
 - **incorrect encoding** on the file.  
 
@@ -41,10 +42,11 @@ Remember, if your language is in UTF8, then you MUST encode the file as "UTF8-wi
 a) look for where it 'started at'  
 b) track the line number  
 c) check what's normally happening on that line.  
---- If it's the end of the file, then it's blank spaces.  
---- If it's the start of the file, it's likely spaces or incorrect encoding.  
---- Elsewhere it could be a syntax error or the result of an "echo()" statement which is displaying info or perhaps debug code.  
---- Common syntax errors include the use of single-quotes inside statements that already have single-quotes. Check to be sure your quotes aren't mismatched. If you need to use single-quotes while inside other single-quotes, change yours to \' instead of just '.  
+
+- If it's the end of the file, then it's blank spaces.  
+- If it's the start of the file, it's likely spaces or incorrect encoding.  
+- Elsewhere it could be a syntax error or the result of an "echo()" statement which is displaying info or perhaps debug code.  
+- Common syntax errors include the use of single-quotes inside statements that already have single-quotes. Check to be sure your quotes aren't mismatched. If you need to use single-quotes while inside other single-quotes, change yours to \' instead of just '.  
 d) the rest of the info simply shows other execution information, mainly the part of the code that discovered that it cannot proceed as expected due to the problem that happened in the 'started at' location.  
 
 To change the encoding on the file, look for the "Save As" menu item in your


### PR DESCRIPTION
When following unformatted text this is required or display will not be correct.

Following formatted text (a header for example) it's optional - I did it in a few cases here because I was worried about copy and paste or removing formatting. 

A few other small changes are included if I was fixing a bulleted list in the same file but this is mostly the bulleted list fix. 