### PR TITLE
Remove duplicate title tag

### DIFF
--- a/layouts/user/baseof.html
+++ b/layouts/user/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }}">
     <header>


### PR DESCRIPTION
Resolves html validation by including the title twice in the `<head>` and fixes #232.