### PR TITLE
Docs nest ul in li sidebox

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -1,0 +1,142 @@
+//
+// Left side navigation
+//
+.td-sidebar-nav {
+    padding-right: 0.5rem;
+    margin-right: -15px;
+    margin-left: -15px;
+
+    @include media-breakpoint-up(md) {
+        @supports (position: sticky) {
+            max-height: calc(100vh - 10rem);
+            overflow-y: auto;
+        }
+    }
+
+
+    @include media-breakpoint-up(md) {
+        display: block !important;
+    }
+
+
+    &__section {
+        li {
+            list-style: none;
+        }
+
+        ul {
+            padding: 0;
+            margin: 0;
+        }
+
+        li > ul {
+            padding: 0;
+            margin: 0;
+        }
+
+        @include media-breakpoint-up(md) {
+            & > ul {
+                padding-left: .5rem;
+            }
+        }
+
+        @include media-breakpoint-up(md) {
+            & > li > ul {
+                padding-left: .5rem;
+            }
+        }
+
+        padding-left: 0;
+    }
+
+    &__section-title {
+        display: block;
+        font-weight: $font-weight-medium;
+
+        .active {
+            font-weight: $font-weight-bold;
+        }
+
+        a {
+            color: $gray-900;
+        }
+    }
+
+    .td-sidebar-link {
+        display: block;
+        padding-bottom: 0.375rem;
+
+        &__page {
+            color: $gray-700;
+            font-weight: $font-weight-light;
+        }
+    }
+
+    a {
+        &:hover {
+            color: $blue;
+            text-decoration: none;
+        }
+
+        &.active {
+            font-weight: $font-weight-bold;
+        }
+    }
+
+    .dropdown {
+        a {
+            color: $gray-700;
+        }
+
+        .nav-link {
+             padding: 0 0 1rem;
+        }
+    }
+}
+
+.td-sidebar {
+    @include media-breakpoint-up(md) {
+        padding-top: 4rem;
+        background-color: $td-sidebar-bg-color;
+        padding-right: 1rem;
+        border-right: 1px solid $td-sidebar-border-color;
+    }
+
+
+    padding-bottom: 1rem;
+
+    &__toggle {
+        line-height: 1;
+        color: $gray-900;
+        margin: 1rem;
+    }
+
+    &__search {
+        padding: 1rem 15px;
+        margin-right: -15px;
+        margin-left: -15px;
+    }
+
+    &__inner {
+        order: 0;
+
+        @include media-breakpoint-up(md) {
+            @supports (position: sticky) {
+                position: sticky;
+                top: 4rem;
+                z-index: 10;
+                height: calc(100vh - 6rem);
+            }
+        }
+
+
+        @include media-breakpoint-up(xl) {
+            flex: 0 1 320px;
+        }
+
+
+        .td-search-box {
+            width: 100%;
+        }
+    }
+}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -1,0 +1,49 @@
+{{/* We cache this partial for bigger sites and set the active class client side. */}}
+{{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
+<div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
+  {{ if not .Site.Params.ui.sidebar_search_disable }}
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  {{ end }}
+  <nav class="collapse td-sidebar-nav pt-2 pl-4" id="td-section-nav">
+    {{ if  (gt (len .Site.Home.Translations) 0) }}
+    <div class="nav-item dropdown d-block d-lg-none">
+      {{ partial "navbar-lang-selector.html" . }}
+    </div>
+    {{ end }}
+    {{ template "section-tree-nav-section" (dict "page" . "section" .FirstSection "delayActive" $shouldDelayActive)  }}
+  </nav>
+</div>
+{{ define "section-tree-nav-section" }}
+{{ $s := .section }}
+{{ $p := .page }}
+{{ $shouldDelayActive := .delayActive }}
+{{ $active := eq $p.CurrentSection $s }}
+{{ $show := or (and (not $p.Site.Params.ui.sidebar_menu_compact) ($p.IsAncestor $s)) ($p.IsDescendant $s) }}
+{{ $sid := $s.RelPermalink | anchorize }}
+<ul class="td-sidebar-nav__section pr-md-3">
+  <li class="td-sidebar-nav__section-title">
+    <a  href="{{ $s.RelPermalink }}" class="align-left pl-0 pr-2{{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__section">{{ $s.LinkTitle }}</a>
+  </li>
+  <li>
+    <ul>
+      <li class="collapse {{ if $show }}show{{ end }}" id="{{ $sid }}">
+        {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
+        {{ $pages := $pages | first 50 }}
+        {{ range $pages }}
+        {{ if .IsPage }}
+        {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
+        {{ $active := eq . $p }}
+        <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+        {{ else }}
+        {{ template "section-tree-nav-section" (dict "page" $p "section" .) }}
+        {{ end }}
+        {{ end }}
+      </li>
+    </ul>
+  </li>
+</ul>
+{{ end }}


### PR DESCRIPTION
Corrects html validation items as described in the associated commits and fixes #234.

Appears somewhat similar to #235, though a little different in the `sidebox-tree.html` file and also added CSS rules rather than modifying them.