### PR TITLE
Modified to bring in line with 1.5.7

### DIFF
--- a/content/user/admin_pages/localization/languages.md
+++ b/content/user/admin_pages/localization/languages.md
@@ -20,11 +20,11 @@ This is the two-letter ISO 639 two-letter language code, e.g. en for English, fr
 
 ### Image
 
-This would be a small icon used to identify the language. This would most likely be a gif image of the typical flag for some country commonly associated with that language.
+This would be a small icon used to identify the language. This would most likely be a gif image of the typical flag for some country commonly associated with that language. This should be located in the `/includes/languages/YOURLANGUAGE/images`
 
 ### Directory
 
-This directory is where the translated php source files for this language are contained. For example, the directory for the English language is located at 
+This directory is where the translated php source files for this language are contained. For example, enter '*english*' the directory for the English language is located at 
 `/includes/languages/english`. 
 
 ### Sort order
@@ -36,6 +36,10 @@ This is the order that the languages are to appear in. Lower numbers are shown h
 Check this box if this is the default language for this site.
 
 When you finish entering data, click on the _insert_ button to add the new language. Click on the _cancel_ button to discard this form.
+
+If you have not yet [installed the language pack](#installing-a-language-pack) you will see the warning message 
+
+    >  <i class="fa fa-2x fa-hand-stop-o"></i> MISSING LANGUAGE FILES OR DIRECTORIES ... YOURLANGUAGE YOURLANGUAGE
 
 ## Edit Language
 
@@ -57,3 +61,14 @@ rename the admin folder if one exists and then upload all the files.
 If you're not familiar how to upload a Zen Cart plugin, follow the instructions on 
 [how to install a plugin](/user/plugins/how_to_install_a_plugin/). 
 
+## Trouble Shooting a Language Pack
+
+- Blank white screen (on storefront) after language pack installed.
+
+    There are likely to be missing language files. Check the logs directory for `myDEBUG-YYYYMMDD-HHMMSS-nnnnnn.log` files and look for `failed to open stream: No such file or directory`. Before it you should see a file path of the missing file. `--> PHP Warning: require_once(**YOURSITE/includes/languages/YOURLANGUAGE/MISSINGFILE.php**): failed to open stream: No such file or directory in YOURSITE/includes/languages/YOURLANGUAGE.php on line 607` find the file in the english language folder YOURSITE/includes/languages/english/MISSINGFILE.php and copy to your language folder.
+**NOTE** - You may have to repeat this task multiple times for older version language packs.
+
+- Capitalised titles displayed in english
+    If you get sections named displayed as capitalised title with underscore between e.g.`HEADING_TITLE` again it will be because language files have not been included in the original language pack. Finding these can be more tricky as the same title may be used in multiple places. Start by loging into your admin page. Then select `Tools > Developers Tool Kit` in the tool kit enter the name of the missing variable and search `All Language Files for ENGLISH - Catalog/Admin` this should produce a list of places where the variable is defined. 
+    - If it is only one place then transfer that file from the english location to YOURLANGUAGE equivalent location
+    - If there a multiple listing then go back to the storefront and add `&language=en` to then end of the URL or if `&language=YOURLANGUAGECODE` is already present change YOURLANGUAGECODE to `en` refresh the page and look at the correct wording. Use this wording to find the correct file and copy the file from the english location to YOURLANGUAGE equivalent location

--- a/content/user/admin_pages/localization/languages.md
+++ b/content/user/admin_pages/localization/languages.md
@@ -20,7 +20,7 @@ This is the two-letter ISO 639 two-letter language code, e.g. en for English, fr
 
 ### Image
 
-This would be a small icon used to identify the language. This would most likely be a gif image of the typical flag for some country commonly associated with that language. This should be located in the `/includes/languages/YOURLANGUAGE/images`
+This would be a small icon used to identify the language. This would most likely be a gif image of the typical flag for some country commonly associated with that language. This should be located in the `/includes/languages/YOURLANGUAGE/images` folder.
 
 ### Directory
 
@@ -39,7 +39,7 @@ When you finish entering data, click on the _insert_ button to add the new langu
 
 If you have not yet [installed the language pack](#installing-a-language-pack) you will see the warning message 
 
-    >  <i class="fa fa-2x fa-hand-stop-o"></i> MISSING LANGUAGE FILES OR DIRECTORIES ... YOURLANGUAGE YOURLANGUAGE
+     MISSING LANGUAGE FILES OR DIRECTORIES ... YOURLANGUAGE YOURLANGUAGE
 
 ## Edit Language
 
@@ -65,10 +65,18 @@ If you're not familiar how to upload a Zen Cart plugin, follow the instructions 
 
 - Blank white screen (on storefront) after language pack installed.
 
-    There are likely to be missing language files. Check the logs directory for `myDEBUG-YYYYMMDD-HHMMSS-nnnnnn.log` files and look for `failed to open stream: No such file or directory`. Before it you should see a file path of the missing file. `--> PHP Warning: require_once(**YOURSITE/includes/languages/YOURLANGUAGE/MISSINGFILE.php**): failed to open stream: No such file or directory in YOURSITE/includes/languages/YOURLANGUAGE.php on line 607` find the file in the english language folder YOURSITE/includes/languages/english/MISSINGFILE.php and copy to your language folder.
+    There are likely to be missing language files. Check the logs directory for `myDEBUG-YYYYMMDD-HHMMSS-nnnnnn.log` files and look for `failed to open stream: No such file or directory`. Before it you should see a file path of the missing file. 
+    
+    ```
+    --> PHP Warning: require_once(**YOURSITE/includes/languages/YOURLANGUAGE/MISSINGFILE.php**): failed to open stream: No such file or directory in YOURSITE/includes/languages/YOURLANGUAGE.php on line 607
+    ``` 
+    
+    Find the file in the english language folder `YOURSITE/includes/languages/english/MISSINGFILE.php` and copy to your language folder.
+    
 **NOTE** - You may have to repeat this task multiple times for older version language packs.
 
 - Capitalised titles displayed in english
     If you get sections named displayed as capitalised title with underscore between e.g.`HEADING_TITLE` again it will be because language files have not been included in the original language pack. Finding these can be more tricky as the same title may be used in multiple places. Start by loging into your admin page. Then select `Tools > Developers Tool Kit` in the tool kit enter the name of the missing variable and search `All Language Files for ENGLISH - Catalog/Admin` this should produce a list of places where the variable is defined. 
+    
     - If it is only one place then transfer that file from the english location to YOURLANGUAGE equivalent location
     - If there a multiple listing then go back to the storefront and add `&language=en` to then end of the URL or if `&language=YOURLANGUAGECODE` is already present change YOURLANGUAGECODE to `en` refresh the page and look at the correct wording. Use this wording to find the correct file and copy the file from the english location to YOURLANGUAGE equivalent location


### PR DESCRIPTION
I have made some changes to this page to add some more examples and make it so that i think it works. I have also added a bit on troubleshooting as i have been trying to make it work with the minimum of details. I was wondering if on installing a language pack we should first get the user to copy over all of the english files this way if the language pack is missing files or zen cart base has added new files they will not be missing when the language pack is installed. I do not know if this is the final version so please be as harsh as you like and let me know what needs changing so that i can get it right.