### PR TITLE
Use the same more help text block in all pages in the footer.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -108,7 +108,7 @@ footer_about_disable = false
 # If you want this feature, but occasionally need to remove the "Feedback" section from a single page,
 # add "hide_feedback: true" to the page's front matter.
 [params.ui.feedback]
-enable = true
+enable = false 
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
 yes = 'Glad to hear it! Please <a href="https://github.com/zencart/documentation/issues/new">tell us how we can improve</a>.'
 no = 'Sorry to hear that. Please <a href="https://github.com/zencart/documentation/issues/new">tell us how we can improve</a>.'

--- a/layouts/codepage/README.txt
+++ b/layouts/codepage/README.txt
@@ -1,0 +1,9 @@
+This was a workaround because the right hand sidebar made it unweildy to have pages with wide blocks of code. 
+
+In the future this folder should be removed and all .md files should 
+have 
+
+type:codepage 
+
+removed from their frontmatter.
+

--- a/layouts/codepage/content.html
+++ b/layouts/codepage/content.html
@@ -2,14 +2,11 @@
 	<h1>{{ .Title }}</h1>
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	{{ .Content }}
-	{{ partial "morehelp.html" . }}
 
+   {{ partial "morehelp.html" . }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
-
-    <div id="feedback">
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
-		<br>
-    </div>
+		<br />
 	{{ end }}
 	{{ if (.Site.DisqusShortname) }}
 		<br />

--- a/layouts/dev/baseof.html
+++ b/layouts/dev/baseof.html
@@ -2,6 +2,17 @@
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
+    <!-- Override normal page styling for maximum code visibility -->
+    <style>
+    .td-content > pre {
+       -webkit-box-sizing: unset !important; 
+       max-width: 100% !important;
+    }
+    main {
+      flex: unset !important; 
+      max-width: 100% !important; 
+    }
+    </style>
   </head>
   <body class="td-{{ .Kind }}">
     <header>
@@ -13,9 +24,7 @@
           <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
             {{ partial "sidebar.html" . }}
           </div>
-          <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
-            {{ partial "toc.html" . }}
-          </div>
+          <!-- no TOC --> 
           <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             {{ block "main" . }}{{ end }}

--- a/layouts/dev/content.html
+++ b/layouts/dev/content.html
@@ -2,14 +2,11 @@
 	<h1>{{ .Title }}</h1>
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	{{ .Content }}
-	{{ partial "morehelp.html" . }}
 
+   {{ partial "morehelp.html" . }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
-
-    <div id="feedback">
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
-		<br>
-    </div>
+		<br />
 	{{ end }}
 	{{ if (.Site.DisqusShortname) }}
 		<br />

--- a/layouts/partials/morehelp.html
+++ b/layouts/partials/morehelp.html
@@ -1,0 +1,15 @@
+    <br><br>
+    <hr id="endcontent">
+    <div id="questions"> 
+        Still have questions?  No problem!  Just head over to the
+        <a href="https://www.zen-cart.com/forum.php"> Zen Cart support forum</a> 
+        and ask there in the appropriate subforum.
+        In your post, please include your <a href="/user/admin_pages/admin_version/">Zen Cart and PHP versions</a>, and a link to your site.
+        <br><br>
+        <div id="eo"> 
+       Is there an error or omission on this page?  Please post to <a href="https://www.zen-cart.com/forumdisplay.php?128-General-Questions">General Questions on the support forum</a>.  Or, if you'd like to open a pull request, just <a href="https://github.com/zencart/documentation/blob/master/CONTRIBUTING.md">review the guidelines</a> and get started. 
+		  {{ partial "footer-edit.html" . }}
+
+        </div>
+        <br><br>
+    </div>

--- a/layouts/user/baseof.html
+++ b/layouts/user/baseof.html
@@ -2,6 +2,17 @@
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
+    <!-- Override normal page styling for maximum code visibility -->
+    <style>
+    .td-content > pre {
+       -webkit-box-sizing: unset !important; 
+       max-width: 100% !important;
+    }
+    main {
+      flex: unset !important; 
+      max-width: 100% !important; 
+    }
+    </style>
   </head>
   <body class="td-{{ .Kind }}">
     <header>
@@ -13,9 +24,7 @@
           <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
             {{ partial "sidebar.html" . }}
           </div>
-          <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
-            {{ partial "toc.html" . }}
-          </div>
+          <!-- no TOC --> 
           <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             {{ block "main" . }}{{ end }}


### PR DESCRIPTION
Turn off right sidebar; edit option is now in the footer for all pages.  This makes individual pages much wider and makes it easy to show code blocks without wrapping. 
