### PR TITLE
Try excluding pages from search

### DIFF
--- a/content/user/admin/_index.md
+++ b/content/user/admin/_index.md
@@ -3,4 +3,5 @@ title: Admin System
 description: Admin controls and how to use them
 weight: 100 
 layout: docs
+nosearch: yes
 ---

--- a/content/user/admin/admin_password.md
+++ b/content/user/admin/admin_password.md
@@ -4,6 +4,7 @@ description: Zen Cart Admin Password - Resetting or Changing
 category: troubleshooting
 weight: 10
 url: /user/troubleshooting/reset_admin_password/
+nosearch: yes
 ---
 
 Just a redirect page 

--- a/content/user/troubleshooting/_index.md
+++ b/content/user/troubleshooting/_index.md
@@ -3,4 +3,5 @@ title: Troubleshooting
 description: Dealing with problems as they come up
 weight: 100 
 layout: docs
+nosearch: yes
 ---

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,5 +1,7 @@
 {{ with .Site.Params.algolia_docsearch }}
+{{ if not .Params.nosearch }}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+{{ end }}
 {{ end }}
 {{ with .Params.customCss }}<link rel="stylesheet" href="{{ . }}" />{{ end }}
 


### PR DESCRIPTION
Right now a search for "Resetting" brings back a bunch of dups because of the presence of this string in the _index files and a redirect page.  Let's try excluding those pages and see if the match performance is better.

If so, make this same change in other redirect / _index files. 
