### PR TITLE
Change addition of px on image width and height

### DIFF
--- a/content/user/new_user_topics/change_header_logo.md
+++ b/content/user/new_user_topics/change_header_logo.md
@@ -25,8 +25,8 @@ For the purpose of this example, let's assume `yourname` is `newlogo.png`, and t
 
 ```
 define('HEADER_ALT_TEXT', 'My new alt text');
-define('HEADER_LOGO_WIDTH', '200px');
-define('HEADER_LOGO_HEIGHT', '80px');
+define('HEADER_LOGO_WIDTH', '200');
+define('HEADER_LOGO_HEIGHT', '80');
 define('HEADER_LOGO_IMAGE', 'newlogo.png');
 ```
 
@@ -57,8 +57,8 @@ A similar change should be made in `admin/includes/languages/english.php`, which
 
 ```
 define('HEADER_ALT_TEXT', 'My new alt text');
-define('HEADER_LOGO_WIDTH', '200px');
-define('HEADER_LOGO_HEIGHT', '80px');
+define('HEADER_LOGO_WIDTH', '200');
+define('HEADER_LOGO_HEIGHT', '80');
 define('HEADER_LOGO_IMAGE', 'newlogo.png');
 ```
 


### PR DESCRIPTION
Using px, em, or any other thing but a digit throws an HTML error.
It would be best to completely remove the width and height defines in the responsive world we live in today but, would the store owner know where to control the width and height?  Or, do we just leave it up to the responsive.css telling it {width:100%;height:auto;}?