### PR TITLE
email_extras.php not located in an override folder

### DIFF
--- a/content/user/email/add_message.md
+++ b/content/user/email/add_message.md
@@ -5,6 +5,6 @@ category: email
 weight: 10
 ---
 
-Since Zen Cart 1.5.6, the capability to add a static message to every email has been built in.  Edit the file `includes/languages/english/YOURTEMPLATE/email_extras.php` and set the defined constant `EMAIL_ORDER_MESSAGE` with your message.  
+Since Zen Cart 1.5.6, the capability to add a static message to every email has been built in.  The original file is located at 'includes/languages/english/email_extras.php'. If you edit the file, save it as `includes/languages/english/YOURTEMPLATE/email_extras.php` to add it to your template's override.  If the file already exists at 'includes/languages/english/YOURTEMPLATE/email_extras.php', then set the defined constant `EMAIL_ORDER_MESSAGE` with your additional message and save the file.  
 
 If your Zen Cart version is older than 1.5.6, you may use the [Order Message](https://www.zen-cart.com/downloads.php?do=file&id=2200) plugin.


### PR DESCRIPTION
If the store owner has not edited the email_extras.php file in the basic includes/languages/english folder,  They will not find the file in an override folder.  Best to tell them to save the original in the override folder or, if the file IS there, edit the EMAIL_ORDER_MESSAGE.