### PR TITLE
Link appears to go to the same page

### DIFF
--- a/content/user/images/additional_images.md
+++ b/content/user/images/additional_images.md
@@ -28,7 +28,7 @@ You have two options:
 
 a) rename your images so they don't share a common filename.  Right now since you have one product with "abc.jpg" as the name, and another product with "abcde.jpg" as the name, both images will show for the "abc.jpg" product, because "abc" is common to both, and "abc" is the full filename of the main image of one of the products.   
 
-This is explained further in [Working with Additional Images](/user/images/adding_multiple_images_to_a_product/). 
+This is explained further in [Image Filename Conventions](/user/images/adding_multiple_images_to_a_product/). 
 
 b) or turn off all extra-image functionality by following 
 the directions above to disable additional images.


### PR DESCRIPTION
At first glance, using the current display for the link, it looks as if the link is going to the site it is already on.

It actually goes to a page titled "Image Filename conventions" (sic)  which should be "Image Filename Conventions"