### PR TITLE
Clarify that the Application secret is 'Production'

### DIFF
--- a/content/user/payment/square_errors.md
+++ b/content/user/payment/square_errors.md
@@ -22,7 +22,7 @@ Customer is attempting to complete a purchase and paying via Square. They login,
 
 1. Click the OAuth link on the left, then click the "Replace secret" button.
 
-1. Click "Show" on the Application secret, and paste it into your Zen Cart Admin. 
+1. Click "Show" on the Production Application secret, and paste it into your Zen Cart Admin. 
 
 If you forgot to click Edit in the first step, you likely have a blank screen on the right hand side of the page when you do click Edit.
 


### PR DESCRIPTION
As the solution for `The provided OAuth access token has expired` error message is also targeted at "non-technical store owners" it would be preferable to ensure the user is working on the Production tab of the Square app (as is already done on the square.md page).

BTW: I believe that the first time the Squareup app page is accessed the tab defaults to Sandbox, for any subsequent visits the Squareup account remembers the users last tab selection - so they may or may not have the Production tab already selected.