### PR TITLE
Adding foldable functionality to sidebar menu sections

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -30,7 +30,7 @@
         }
 
         @include media-breakpoint-up(md) {
-            & > li > ul {
+            & > ul {
                 padding-left: .5rem;
             }
         }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -32,36 +32,79 @@ pre > code {
   }
 }
 
-/* Header - show search box on mobile */
-@media (max-width: 868px){
-.td-navbar {display:block;text-align:center;}
-.td-navbar .td-navbar-nav-scroll {font-size:1rem;}
-ul.navbar-nav.mt-2.mt-lg-0 {display:inline-flex;margin-top:0px!important;margin-left:1.5rem;}
-.td-navbar-cover {background: $primary!important;}
-.navbar-nav.d-none.d-lg-block {display:inline-block!important;margin-right:0.2rem}
-}
-
 /* Header - alignment of elements */
-@media (min-width:869px) and (max-width:937px){
-.navbar-nav.d-none.d-lg-block {max-width:25%;display:inline-block!important;}
-ul.navbar-nav.mt-2.mt-lg-0 {margin-top:0!important;}
-#main_navbar {margin:0.25 auto 0;}
+
+@media (max-width: 768px) {
+  ul.navbar-nav.mt-2.mt-lg-0 {
+    margin-left: 1.5rem;
+  }
 }
 
-@media (min-width:938px) and (max-width: 991px){
-.navbar-nav.d-none.d-lg-block {max-width:27%;display:inline-block!important;margin-right:0.5rem}
-ul.navbar-nav.mt-2.mt-lg-0 {margin-top:0!important;}
+@media (min-width:768px) and (max-width:868px) {
+  #main_navbar {
+    margin: 0;
+  }
 }
 
-@media (min-width:992px) and (max-width:1090px){
-.navbar-nav.d-none.d-lg-block {max-width:27%;}
-ul.navbar-nav.mt-2.mt-lg-0 {margin-top:0!important;}
+@media (min-width:869px) and (max-width:937px) {
+  .navbar-nav.d-none.d-lg-block {
+    max-width: 25%;
+	display: inline-block!important;
+  }
 }
 
-/* Homepage - make header background solid on large screens to prevent text overlap (HACK) */ 
-@media (min-width:869px){
-.td-navbar-cover {background:#955239!important;}	
+@media (min-width:938px) and (max-width: 991px) {
+  .navbar-nav.d-none.d-lg-block {
+    max-width: 27%;
+	display: inline-block!important;
+	margin-right: 0.5rem;
+  }
+}
+
+@media (min-width:992px) and (max-width:1090px) {
+  .navbar-nav.d-none.d-lg-block {
+    max-width: 27%;
+  }
+}
+
+@media (max-width: 1090px) {
+  ul.navbar-nav.mt-2.mt-lg-0 {
+    margin-top: 0!important;
+  }
+}
+
+/* Left Column - min width of search box */
+@media (min-width:768px) {
+  .td-sidebar__search {
+    min-width: 184px;
+  }
+}
+
+@media (min-width:868px) {
+  .td-sidebar__search {
+    display:none!important;
+  }
+  #td-section-nav {
+    padding-top: 0.5rem!important;
+  }
+}
+
+/* Left Column - reduce indent of headings without child */
+
+nav.foldable-nav .without-child {
+  padding-left: 0.7em;
+}
+
+/* Homepage - make header background solid on large screens to prevent text overlap */
+ 
+@media (min-width:869px) {
+  .td-navbar-cover {
+    background: #955239!important;
+  }	
 }
 
 /* Homepage - center body elements */
-ul.mainpage_list {padding-left:0;}
+
+ul.mainpage_list {
+  padding-left:0;
+}

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -1,7 +1,5 @@
 /*
-
 Add styles or override variables from the theme here.
-
 */
 
 .mainpage_list {
@@ -35,4 +33,30 @@ img {
    border: 1px solid black; 
    border-style: solid !important; 
    margin-top: 10px; 
+}
+
+/* Adjust left column and main content sizes to accommodate foldable sidebar sections */
+
+@media (min-width:768px) and (max-width:816px) {
+  .row > main {
+    max-width: 70%!important;
+  }	
+}
+
+@media (min-width:817px) and (max-width:1199px) {
+  .row > main {
+    max-width: 72%!important;
+  }	
+}
+
+@media (min-width:768px) and (max-width:999px) {
+  .td-sidebar {
+    min-width: 14rem;
+  }
+}
+
+@media (min-width:1000px) {
+  .td-sidebar {
+    min-width: 17rem;
+  }
 }

--- a/config.toml
+++ b/config.toml
@@ -94,11 +94,13 @@ offlineSearch = false
 [params.ui]
 # Enable to show the side bar menu in its compact state.
 sidebar_menu_compact = false
-#  Set to true to disable breadcrumb navigation.
+# Set to true to enable foldable menu.
+sidebar_menu_foldable = true
+# Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
-#  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
-sidebar_search_disable = true
-#  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
+# Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
+sidebar_search_disable = false
+# Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
 navbar_logo = true
 # Set to true to disable the About link in the site footer
 footer_about_disable = false
@@ -143,4 +145,3 @@ no = 'Sorry to hear that. Please <a href="https://github.com/zencart/documentati
 
 [outputs]
   home = ["HTML", "RSS"]
-

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -1,47 +1,71 @@
 {{/* We cache this partial for bigger sites and set the active class client side. */}}
-{{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
+{{ $sidebarCacheLimit := cond (isset .Site.Params.ui "sidebar_cache_limit") .Site.Params.ui.sidebar_cache_limit 2000 -}}
+{{ $shouldDelayActive := ge (len .Site.Pages) $sidebarCacheLimit -}}
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
-  {{ if not .Site.Params.ui.sidebar_search_disable }}
+  {{ if not .Site.Params.ui.sidebar_search_disable -}}
   <form class="td-sidebar__search d-flex align-items-center">
     {{ partial "search-input.html" . }}
-    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-section-nav" aria-expanded="false" aria-label="Toggle section navigation">
     </button>
   </form>
-  {{ end }}
-  <nav class="collapse td-sidebar-nav pt-2 pl-4" id="td-section-nav">
-    {{ if  (gt (len .Site.Home.Translations) 0) }}
+  {{ else -}}
+  <div id="content-mobile">
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-section-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  </div>
+  <div id="content-desktop"></div>
+  {{ end -}}
+  <nav class="collapse td-sidebar-nav{{ if .Site.Params.ui.sidebar_menu_foldable }} foldable-nav{{ end }}" id="td-section-nav">
+    {{ if  (gt (len .Site.Home.Translations) 0) -}}
     <div class="nav-item dropdown d-block d-lg-none">
       {{ partial "navbar-lang-selector.html" . }}
     </div>
-    {{ end }}
-    {{ template "section-tree-nav-section" (dict "page" . "section" .FirstSection "delayActive" $shouldDelayActive)  }}
+    {{ end -}}
+    {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
+    {{ $ulNr := 0 -}}
+    {{ $ulShow := cond (isset .Site.Params.ui "ul_show") .Site.Params.ui.ul_show 1 -}}
+    {{ $sidebarMenuTruncate := cond (isset .Site.Params.ui "sidebar_menu_truncate") .Site.Params.ui.sidebar_menu_truncate 50 -}}
+    <ul class="td-sidebar-nav__section pr-md-3 ul-{{ $ulNr }}">
+      {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1)) }}
+    </ul>
   </nav>
 </div>
-{{ define "section-tree-nav-section" }}
-{{ $s := .section }}
-{{ $p := .page }}
-{{ $shouldDelayActive := .delayActive }}
-{{ $active := eq $p.CurrentSection $s }}
-{{ $show := or (and (not $p.Site.Params.ui.sidebar_menu_compact) ($p.IsAncestor $s)) ($p.IsDescendant $s) }}
-{{ $sid := $s.RelPermalink | anchorize }}
-<ul class="td-sidebar-nav__section pr-md-3">
-  <li class="td-sidebar-nav__section-title">
-    <a  href="{{ $s.RelPermalink }}" class="align-left pl-0 pr-2{{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__section">{{ $s.LinkTitle }}</a>
-   <ul>
-    <li class="collapse {{ if $show }}show{{ end }}" id="{{ $sid }}">
-      {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
-      {{ $pages := $pages | first 50 }}
-      {{ range $pages }}
-      {{ if .IsPage }}
-      {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
-      {{ $active := eq . $p }}
-      <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
-      {{ else }}
-      {{ template "section-tree-nav-section" (dict "page" $p "section" .) }}
-      {{ end }}
-      {{ end }}
-    </li>
-   </ul>
-  </li>
-</ul>
-{{ end }}
+{{ define "section-tree-nav-section" -}}
+{{ $s := .section -}}
+{{ $p := .page -}}
+{{ $shouldDelayActive := .shouldDelayActive -}}
+{{ $sidebarMenuTruncate := .sidebarMenuTruncate -}}
+{{ $treeRoot := cond (eq .ulNr 0) true false -}}
+{{ $ulNr := .ulNr -}}
+{{ $ulShow := .ulShow -}}
+{{ $active := and (not $shouldDelayActive) (eq $s $p) -}}
+{{ $activePath := and (not $shouldDelayActive) (or (eq $p $s) ($p.IsDescendant $s)) -}}
+{{ $show := cond (or (lt $ulNr $ulShow) $activePath (and (not $shouldDelayActive) (eq $s.Parent $p.Parent)) (and (not $shouldDelayActive) (eq $s.Parent $p)) (not $p.Site.Params.ui.sidebar_menu_compact) (and (not $shouldDelayActive) ($p.IsDescendant $s.Parent))) true false -}}
+{{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) -}}
+{{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
+{{ $pages := $pages_tmp | first $sidebarMenuTruncate -}}
+{{ $withChild := gt (len $pages) 0 -}}
+{{ $manualLink := cond (isset $s.Params "manuallink") $s.Params.manualLink ( cond (isset $s.Params "manuallinkrelref") (relref $s $s.Params.manualLinkRelref) $s.RelPermalink) -}}
+{{ $manualLinkTitle := cond (isset $s.Params "manuallinktitle") $s.Params.manualLinkTitle $s.Title -}}
+<li class="td-sidebar-nav__section-title td-sidebar-nav__section{{ if $withChild }} with-child{{ else }} without-child{{ end }}{{ if $activePath }} active-path{{ end }}{{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} collapse{{ end }}" id="{{ $mid }}-li">
+  {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) -}}
+  <input type="checkbox" id="{{ $mid }}-check"{{ if $activePath}} checked{{ end }}/>
+  <label for="{{ $mid }}-check"><a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0 {{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a></label>
+  {{ else -}}
+  <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a>
+  {{- end }}
+  {{- if $withChild }}
+  {{- $ulNr := add $ulNr 1 }}
+  <ul class="ul-{{ $ulNr }}{{ if (gt $ulNr 1)}} foldable{{end}}">
+    {{ range $pages -}}
+    {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) -}}
+    {{ template "section-tree-nav-section" (dict "page" $p "section" . "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" $ulShow) }}
+    {{- end }}
+    {{- end }}
+  </ul>
+  {{- end }}
+</li>
+{{- end }}


### PR DESCRIPTION
Fixes #847

**Important:** The Docsy theme update (`themes/docsy`) required for the foldable sidebar is **not** compatible with the current version of Hugo used by ZC Documentation, v0.74.3, as specified in `netlify.toml`. A more recent version needs to be used when deploying to Netlify - I have **not** changed this .toml file. (This PR was tested running hugo v0.101.0).

`themes/docsy` Changed docsy submodule commit to a more recent one (FYI - the commit used is just **prior** to docsy dropping the Bootstrap and Font Awesome submodules in favour of using NPM packages instead)

`config.toml` Added foldable sidebar menu to site parameters.

`layouts/partials/sidebar-tree.html` Replaced contents with that of new docsy submodule.

`assets/scss/_variables_project.scss` Adjusted sizes of left column and main content area to accommodate foldable sidebar sections.

`assets/scss/_styles_project.scss` General styling to accommodate all screen sizes.

`assets/scss/_sidebar-tree.scss` Removed previous customisation by @drbyte as no longer needed with this theme update.

**Note: the automated checks on this PR will fail due to the version of Hugo being used (above).**