### PR TITLE
Correct Color Contrast for Footer Links

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -65,3 +65,7 @@ ul.navbar-nav.mt-2.mt-lg-0 {margin-top:0!important;}
 
 /* Homepage - center body elements */
 ul.mainpage_list {padding-left:0;}
+
+/* Homepage - Correct Color Contrast for Footer Links */
+.col-12.col-sm-4.text-center.py-2.order-sm-2 a {color: #6aafff;}
+.col-12.col-sm-4.text-center.py-2.order-sm-2 a:hover {color: #f2f2f2;}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -69,3 +69,10 @@ ul.mainpage_list {padding-left:0;}
 /* Homepage - Correct Color Contrast for Footer Links */
 .col-12.col-sm-4.text-center.py-2.order-sm-2 a {color: #6aafff;}
 .col-12.col-sm-4.text-center.py-2.order-sm-2 a:hover {color: #f2f2f2;}
+
+/* Change settings to make the current home page fit on a desktop screen */
+.container.td-overlay__inner {max-width: 100%;}
+section#td-cover-block-0 {padding-top: 1rem;padding-bottom: 0;}
+main.td-main hr {margin-top: 0;margin-bottom: 0;}
+a.nav-link {color: #ffffff !important;}
+a.nav-link:hover {color: #ffdd99;}


### PR DESCRIPTION
Currently, the links in the footer of the docs do not meet the 4.5:1 ratio for color contrast and are even worse when you hover on them.
This fix keeps the background color and changes the font colors for the a and a:hover to bring them into compliance.