### PR TITLE
Fix template issue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,1 @@
 
-[submodule "themes/docsy"]
-	path = themes/docsy
-	url = https://github.com/google/docsy.git

--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@ title = "Zen Cart Docs"
 enableRobotsTXT = true
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
-theme = ["docsy"]
+theme = ["github.com/google/docsy", "github.com/google/docsy/dependencies"]
 
 # Will give values to .Lastmod etc.
 enableGitInfo = true

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/scottcwilson/zencart_documentation
+
+go 1.19
+
+require github.com/google/docsy v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.4.0 h1:Eyt2aiDC1fnw/Qq/9xnIqUU5n5Yyk4c8gX3nBDdTv/4=
+github.com/google/docsy v0.4.0/go.mod h1:vJjGkHNaw9bO42gpFTWwAUzHZWZEVlK46Kx7ikY5c7Y=
+github.com/google/docsy/dependencies v0.4.0/go.mod h1:2zZxHF+2qvkyXhLZtsbnqMotxMukJXLaf8fAZER48oo=
+github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
Fixes 

WARN 2022/09/16 07:09:46 The google_news internal template will be removed in a future release. Please remove calls to this template. See https://github.com/gohugoio/hugo/issues/9172 for additional information.

Updated docsy using 

https://www.docsy.dev/docs/updating/convert-site-to-module/