### PR TITLE
Updates for extending objectInfo

### DIFF
--- a/content/dev/plugins/upgrading_to_158.md
+++ b/content/dev/plugins/upgrading_to_158.md
@@ -29,6 +29,34 @@ will no longer work for 1.5.8 and above.  However, plugin authors may want to ma
   }
 ```
 
-### Creating Definitions 
+### PHP 8.2 objectInfo and plugins 
 
+PHP 8.2 introduces a new restriction which deprecates the use of dynamic properties.  For core modules in admin, the `objectInfo` class has been extended to contain all possible data elements (based on the creation of an instance from a query result).  Plugin developers using custom tables (or even references to built-in tables which are not used by other core modules) should simply extend `objectInfo`.  Consider the following example from Email Archive Manager: 
+
+```
+  class eam_objectInfo extends objectInfo {
+     public 
+        $archive_id, 
+        $email_to_name,
+        $email_to_address,
+        $email_from_name,
+        $email_from_address,
+        $email_subject,
+        $email_html,
+        $email_text; 
+  }
+
+```
+
+Then, in the code body, instead of  
+
+```
+$email = new objectInfo($email_sql->fields);
+``` 
+
+use 
+
+```
+$email = new eam_objectInfo($email_sql->fields);
+```
 


### PR DESCRIPTION
Dynamic property update deprecation means you cannot simply create an objectInfo and get an object with arbitrary fields.  