### PR TITLE
Update newsletters.md

### DIFF
--- a/content/user/email/newsletters.md
+++ b/content/user/email/newsletters.md
@@ -35,8 +35,12 @@ Some names you might have heard of are Constant Contact, SendInBlue, and Sendy.
 
 If you want to look for other options, do a web search for "newsletter provider service."
 
-### Admin Settings when using an Email Service Provider
+### Hosting Requirements
+With the current emphasis on [SPF, DKIM, and DMARC](/user/email/advanced_email_troubleshooting/#11-spf-dkim-and-dmarc) to verify your site's emails, you may be required to make a couple of extra settings in your site's DNS to include your Email Service Provider.  Espeically if your email is hosted other than at Mail Chimp or one of its alternatives.  Without this setting, you will probably receive a multitude of bounces.  Unfortunately, those bounces may not be reported to you or your customer.  If your Email Service Provider does not provide this setting, you will most likely have problems reaching all your customers with your latest promotion.
 
+This setting tells the recipient that MailChimp or its alternative has "permission" to send emails using your email host and address.  It is generally in the form of a TXT entry with the name having an identifier something like k2.\_domainkey.yoursite.com or mail.\_domainkey.yoursite.com.  Your email service provider should have information if you search for "setup email domain authentication."  Current MailChimp instructions are available [here](https://mailchimp.com/help/set-up-email-domain-authentication/).The record itself will be a rather large string of text and may need to be added by your host if you are unable to add TXT settings to your site's DNS.  If you are able to make the entry yourself, make sure you accurately copy the information provided by your Email Service Provider.
+
+### Admin Settings when using an Email Service Provider
 Because you are no longer using Zen Cart's newsletter feature, you will want to stop capturing signups through Zen Cart.
 
 - Turn off [Show Newsletter Checkbox](/user/admin_pages/configuration/configuration_customerdetails/#show_newsletter_checkbox) in Admin > Configuration > Customer Details. 
@@ -44,7 +48,6 @@ Because you are no longer using Zen Cart's newsletter feature, you will want to 
 - Turn off [Display "Newsletter Unsubscribe" Link](/user/admin_pages/configuration/configuration_email/#display_newsletter_unsubscribe_link) in Admin > Configuration > Email. 
 
 ### Handling Subscribes and Unsubscribes
-
 Most Email Service Providers will provide you with a signup form to use on your website that allows you to allow people to signup for your newsletter.  Use this form, either as a [sidebox](/user/template/sideboxes/) or as a [new custom page](/user/customizing/add_pages/#build-a-new-custom-page). 
 
 Generally unsubscribes will be done by clicking the unsubscribe link that is provided at the bottom of your newsletter; doing this within your cart is somewhat complicated and will require custom coding.


### PR DESCRIPTION
Add the .domainkey TXT entries needed in a site's DNS to authorize Email Service Providers who use the site's email address and email host.

Modern email checking through the whole process will result in a large percentage of bounces without this DNS entry.

Fortunately, most services provide the code for the user to insert in their DNS.