### PR TITLE
Footer white space removal

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -23,6 +23,10 @@ pre > code {
   flex-grow: unset; 
 }
 
+footer {
+  min-height: auto;
+}
+
 /* Hide description on leaf pages */ 
 .td-page {
   .td-content {


### PR DESCRIPTION
This has been bugging me for a while. At certain viewport sizes the gray footer background fails to fully fill the available space [images below] - leaving a white space that can obscure text/links. Removing the footer's css `min-height` constraints fixes the issue with no apparent ill-effects.

![Screenshot 2025-01-12 103232](https://github.com/user-attachments/assets/b4a4362e-3139-487c-a5e3-19985eefdb12)

![Screenshot 2025-01-12 103314](https://github.com/user-attachments/assets/e5574c2a-98b1-432e-885b-aa31fc77636e)
