### PR TITLE
Change hover state of foldable menu icons

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -351,3 +351,12 @@ margin:0 auto;
     margin:0.2rem 0 0 0;
   }  
 } 
+
+@media (hover: hover) and (pointer: fine) {
+  nav.foldable-nav .ul-1 .with-child > label:hover::before {
+    transform:none;
+  }
+  nav.foldable-nav .ul-1 .with-child > input:checked ~ label:hover::before {
+    transform: rotate(90deg) !important;
+  }
+}


### PR DESCRIPTION
The default behaviour of the foldable menu icons (triangles) has, on hover/click, three states: 30, 60 & 90 deg. I think this is overkill (and a little weird). This PR proposes a simpler behaviour in that there is no change on hover and just a 90 deg change on click.