### PR TITLE
Adding French Language to the list of supported language for ZC 1.58+

### DIFF
--- a/content/user/languages/updated_language_packs.md
+++ b/content/user/languages/updated_language_packs.md
@@ -9,6 +9,7 @@ Thanks to the efforts of our volunteers, these updated language files are ready 
 
 - [Dutch](https://www.zen-cart.com/downloads.php?do=file&id=2376)
 - [Finnish](https://www.zen-cart.com/downloads.php?do=file&id=242)
+- [French](https://www.zen-cart.com/downloads.php?do=file&id=2391)
 - Italian coming soon from the Zen Cart Italia team!
 - [Japanese](https://www.zen-cart.com/downloads.php?do=file&id=2359)
 - [Spanish](https://github.com/torvista/Zen_Cart-Spanish_Language_Pack) 


### PR DESCRIPTION
Adding French Language to the list of supported language for ZC 1.58+ in updated_language_packs.md.